### PR TITLE
feat: push development image to docker hub

### DIFF
--- a/.github/workflows/pull-images.yml
+++ b/.github/workflows/pull-images.yml
@@ -1,0 +1,26 @@
+# Pull the Docker images from Docker Hub on schedule
+name: Pull Docker Images
+
+on:
+  schedule:
+    # Runs "At 00:00 on day-of-month 1 in every 2nd month."
+    - cron: '0 0 1 */2 *'
+
+jobs:
+  pull-images:
+    name: Pull Development Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Fetch and check out latest tag
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Checking out latest tag: $LATEST_TAG"
+          git checkout $LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Pull Development Image
+        run: docker compose -f docker-compose.dev.yml pull

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,29 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out
           publish_branch: gh-pages
+
+  docker-build-push:
+    name: Push Image to Docker Hub
+    if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    needs: lint-export-client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Create env variables
+        run: cp client/.env.example client/.env
+
+      - name: Build Image
+        run: docker compose -f docker-compose.dev.yml build
+
+      - name: Push Image to Docker Hub
+        run: docker compose -f docker-compose.dev.yml push

--- a/README.md
+++ b/README.md
@@ -97,23 +97,49 @@ https://sites.google.com/view/gsites-embed-app/full-page
 
 2. Follow the instructions in the README files inside the **/client** and **/server** directories for more information on configuring and using the client and server apps.
 
-3. Create an account after setting up the **/server** `.env` using the instructions in it's README file.<br>
-   - Navigate to the /server directory from the commandline and run:<br>
+3. Create an account after setting up the **/server** `.env` using the instructions in its README file.<br>
+   - Navigate to the /server directory from the command line and run:<br>
 `npm run user:create --email=randomemail@gmail.com --password=anypasasword --displayname="Game Tester" --emailverified=true`
 
 ## Run with Docker
 
-```
-# Run on development mode
-docker compose -f docker-compose.dev.yml build
-docker compose -f docker-compose.dev.yml up
-docker compose -f docker-compose.dev.yml down
+### Build Images Locally
 
-# Build and run for production mode
-docker compose -f docker-compose.prod.yml build
-docker compose -f docker-compose.prod.yml up
-docker compose -f docker-compose.prod.yml down
-```
+1. Build the images locally, then run.
+2. Follow the instructions under the [Installation](#installation) section for more information after spinning up a container.
+
+   ```
+   # Run on development mode
+   docker compose -f docker-compose.dev.yml build
+   docker compose -f docker-compose.dev.yml up
+   docker compose -f docker-compose.dev.yml down
+
+   # Build and run for production mode
+   docker compose -f docker-compose.prod.yml build
+   docker compose -f docker-compose.prod.yml up
+   docker compose -f docker-compose.prod.yml down
+   ```
+
+### Using the Pre-Built Docker Image
+
+This project deploys the latest development Docker image to Docker Hub on the creation of new Release/Tags. It is available at:<br>
+https://hub.docker.com/repository/docker/weaponsforge/gsites-components
+
+1. Pull the pre-built development Docker image using any of the two (2) options:
+   - Open a terminal and run:<br>
+   `docker pull weaponsforge/gsites-components:latest`
+
+   - Navigate to the gsites-components root project directory, then run:<br>
+   `docker compose -f docker-compose.dev.yml pull`
+
+2. Follow the instructions in the README files inside the **/client** and **/server** directories for more information on configuring and using the client and server apps.
+
+3. Run the development image.<br>
+`docker compose -f docker-compose.dev.yml up`
+
+4. Create user accounts after setting up the **/server** `.env` using the instructions in its README file.<br>
+   - Navigate to the /server directory from the command line and run:<br>
+`docker exec -it gsites-client-dev npm run user:create --email=randomemail@gmail.com --password=anypasasword --displayname="Game Tester" --emailverified=true`
 
 ## Deploy With GitHub Actions
 
@@ -140,6 +166,8 @@ Follow the steps to self-host the project in your own repository and Firebase pr
 
 Create the following GitHub Secrets, using values from the Firebase (web) configuration and settings from the requirements.
 
+#### GitHub Secrets
+
 | GitHub Secret | Description |
 | --- | --- |
 | NEXT_PUBLIC_BASE_PATH | Root directory path name that NextJS uses for assets, media and client-side routing for the app.<br><br>Set its value to blank `''` when working on development mode in localhost.<br><br>Set its value to the sub-directory name where the exported NextJS app is to be deployed, i.e. `/<YOUR_REPOSITORY_NAME>` when<br> deploying on a repository (sub-directory) of a root GitHub Pages site, i.e, on `https://<YOUR_GITHUB_USERNAME>.github.io/<YOUR_REPOSITORY_NAME>` |
@@ -153,6 +181,15 @@ Create the following GitHub Secrets, using values from the Firebase (web) config
 | FIREBASE_WEB_STORAGE_BUCKET_PROD | Firebase web storage bucket key from the Firebase Project Settings configuration file for the (production) environment. |
 | FIREBASE_TOKEN | Firebase CLI deploy token, retrieved with `"firebase login:ci"` |
 | FIREBASE_HOSTING_DEV | Firebase Hosting name under the `FIREBASE_WEB_PROJECT_ID_DEV` |
+| DOCKERHUB_USERNAME | (Optional) Docker Hub username. Required to enable pushing the development image to Docker Hub. |
+| DOCKERHUB_TOKEN | (Optional) Deploy token for the Docker Hub account. Required to enable pushing the development image to Docker Hub. |
+
+#### GitHub Variables
+
+| GitHub Variable | Description |
+| --- | --- |
+| DOCKERHUB_USERNAME | (Optional) Docker Hub username. Required to enable pushing the development image to Docker Hub. |
+
 
 ### 2. Firebase Hosting
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
   # NextJS v13 app running on development mode
   gsites-client-dev:
     container_name: gsites-client-dev
-    image: weaponsforge/gsites-client:dev
+    image: weaponsforge/gsites-client:latest
     env_file:
       - ./client/.env
     build:
@@ -21,7 +21,7 @@ services:
   # Node CLI for running scripts
   gsites-server-dev:
     container_name: gsites-server-dev
-    image: weaponsforge/gsites-server:dev
+    image: weaponsforge/gsites-server:latest
     env_file:
       - ./server/.env
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ services:
   # NextJS exported app running on an nginx webserver
   gsites-client-prod:
     container_name: gsites-client-prod
-    image: weaponsforge/gsites-client:latest
+    image: weaponsforge/gsites-client:prod
     restart: always
     build:
       context: ./client


### PR DESCRIPTION
- Feat: Push the latest development image to Docker Hub on creation of new Release/Tags, [#151](https://github.com/weaponsforge/gsites-components/issues/151) 
- Feat: Pull the development image every 2 months (to keep it active in the free Docker Hub account)